### PR TITLE
Use SpanId.isValid before setting parent span ID attr

### DIFF
--- a/exporters/src/main/java/io/honeycomb/opentelemetry/exporters/HoneycombSpanExporter.java
+++ b/exporters/src/main/java/io/honeycomb/opentelemetry/exporters/HoneycombSpanExporter.java
@@ -7,6 +7,8 @@ import io.opentelemetry.common.AttributeKey;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
+import io.opentelemetry.trace.SpanId;
+
 import java.util.Collection;
 import java.util.concurrent.TimeUnit;
 
@@ -61,7 +63,7 @@ public class HoneycombSpanExporter implements SpanExporter {
         if (!span.getName().isEmpty()) {
             event.addField(AttributeNames.SPAN_NAME_FIELD, span.getName());
         }
-        if (!span.getParentSpanId().isEmpty()) {
+        if (SpanId.isValid(span.getParentSpanId())) {
             event.addField(AttributeNames.PARENT_ID_FIELD, span.getParentSpanId());
         }
         if (span.getKind() != null) {

--- a/exporters/src/test/java/io/honeycomb/opentelemetry/exporters/HoneycombSpanExporterTest.java
+++ b/exporters/src/test/java/io/honeycomb/opentelemetry/exporters/HoneycombSpanExporterTest.java
@@ -106,4 +106,21 @@ public class HoneycombSpanExporterTest {
         // verify(mockEvent, times(1)).addField("rBoolean", false);
         verifyNoMoreInteractions(mockClient);
     }
+
+    @Test
+    public void testSpanWithoutParentShouldNotSetParentIdAttribute() {
+        when(mockClient.createEvent()).thenReturn(mockEvent);
+        when(mockEvent.addField(any(String.class), any(Object.class))).thenReturn(mockEvent);
+        when(mockEvent.setTimestamp(any(Long.class))).thenReturn(mockEvent);
+
+        SpanData span = TestSpanData.newBuilder()
+            .setTraceId("000000000063d76f0000000037fe0393")
+            .setSpanId("000000000012d685")
+            .build();
+
+        HoneycombSpanExporter exporter = new HoneycombSpanExporter(mockClient, serviceName);
+        exporter.export(Arrays.asList(span));
+
+        verify(mockEvent, times(0)).addField(AttributeNames.PARENT_ID_FIELD, span.getParentSpanId());
+    }
 }


### PR DESCRIPTION
The current check only validates the span's parent span ID is not not empty, however we need to also check it is valid (ie not equal to `0000000000000000`).

This update uses the `SpanId.isValid()` function to validate the parent Id before settings the attribute and adds a test to ensure the attribute is not added.